### PR TITLE
Link example headers to corresponding files/links

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,32 +2,32 @@
 
 Here we have put together a hand full of ruby examples to help get you started. Please read through the official [API Documentation](../README.md#api-documentation) to get a complete sense of what to expect from each endpoint. As always, feel free to [contact us](https://lob.com/support) directly if you have any questions on implementation.
 
-## /csv_checks/
+## [/csv_checks/](./csv_checks/)
 
 An example showing how to dynamically create checks from a CSV using HTML, merge variables, and Lob's [Checks API](https://lob.com/services/checks).
 
-## /csv_letters/
+## [/csv_letters/](./csv_letters/)
 
 An example showing how to dynamically create letters from a CSV using HTML, a custom font, merge variables, and Lob's [Letters API](https://lob.com/services/letters).
 
-## /csv_postcards/
+## [/csv_postcards/](./csv_postcards/)
 
 An example showing how to dynamically create postcards from a CSV using HTML, a custom font, merge variables, and Lob's [Postcards API](https://lob.com/services/postcards).
 
-## /csv_verify/
+## [/csv_verify/](./csv_verify/)
 
 An example showing how to validate and cleanse a CSV spreadsheet full of shipping addresses using Lob's [US Verification API](https://lob.com/services/verifications).
   		  
 Please note that if you are running this with a Test API Key, the verification API will always return [a dummy address](https://lob.com/docs#us_verifications_create).
 
-## /checks.rb
+## [/checks.rb](./letters.rb)
 
 An example showing how to create a check using Lob's [Checks API](https://lob.com/services/checks).
 
-## /letters.rb
+## [/letters.rb](./letters.rb)
 
 An example showing how to create a letter using Lob's [Letters API](https://lob.com/services/letters).
 
-## /postcards.rb
+## [/postcards.rb](./postcards.rb)
 
 An example showing how to create a postcard using Lob's [Postcards API](https://lob.com/services/postcards).


### PR DESCRIPTION
Allow user to click on referenced file instead of scrolling up the page.